### PR TITLE
Missing apt for install command.

### DIFF
--- a/README-Microsoft.WSL2
+++ b/README-Microsoft.WSL2
@@ -1,5 +1,5 @@
 Build instructions:
 
 1. Install a recent Ubuntu distribution
-2. sudo install build-essential flex bison libssl-dev libelf-dev
+2. sudo apt install build-essential flex bison libssl-dev libelf-dev
 3. make KCONFIG_CONFIG=Microsoft/config-wsl


### PR DESCRIPTION
When running the initial dependencies install, it failed. Adding 'apt' before install, worked fine. Appears it was just missing from the README.