### PR TITLE
added missing "apt-get" on step 2

### DIFF
--- a/README-Microsoft.WSL2
+++ b/README-Microsoft.WSL2
@@ -1,5 +1,5 @@
 Build instructions:
 
 1. Install a recent Ubuntu distribution
-2. sudo install build-essential flex bison libssl-dev libelf-dev
+2. sudo apt-get install build-essential flex bison libssl-dev libelf-dev
 3. make KCONFIG_CONFIG=Microsoft/config-wsl


### PR DESCRIPTION
the step 2 is missing the command `apt` or `apt-get`, which generates an error when copying/pasting `sudo install ...` > command `install` not found.