### PR TITLE
fix tools/perf bugs: perf_env__arch return dangling pointer, normalize_arch function read out of bound, global variable multiple defined

### DIFF
--- a/tools/perf/arch/common.c
+++ b/tools/perf/arch/common.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 #include <stdio.h>
+#include <sys/utsname.h>
 #include "common.h"
 #include "../util/env.h"
 #include "../util/util.h"
@@ -117,12 +118,13 @@ static int lookup_triplets(const char *const *triplets, const char *name)
 	}
 	return -1;
 }
-
+#define fldsz(name, field)  (sizeof(((struct name *)0)->field))
 static int perf_env__lookup_binutils_path(struct perf_env *env,
 					  const char *name, const char **path)
 {
 	int idx;
-	const char *arch = perf_env__arch(env), *cross_env;
+	char arch_name_buf[fldsz(utsname ,machine)];
+	const char *arch = perf_env__arch(env,arch_name_buf), *cross_env;
 	const char *const *path_list;
 	char *buf = NULL;
 
@@ -130,7 +132,7 @@ static int perf_env__lookup_binutils_path(struct perf_env *env,
 	 * We don't need to try to find objdump path for native system.
 	 * Just use default binutils path (e.g.: "objdump").
 	 */
-	if (!strcmp(perf_env__arch(NULL), arch))
+	if (!strcmp(perf_env__arch(NULL,arch_name_buf), arch))
 		goto out;
 
 	cross_env = getenv("CROSS_COMPILE");
@@ -208,5 +210,6 @@ int perf_env__lookup_objdump(struct perf_env *env, const char **path)
  */
 bool perf_env__single_address_space(struct perf_env *env)
 {
-	return strcmp(perf_env__arch(env), "sparc");
+	char arch_name_buf[fldsz(utsname ,machine)];
+	return strcmp(perf_env__arch(env,arch_name_buf), "sparc");
 }

--- a/tools/perf/bench/futex-hash.c
+++ b/tools/perf/bench/futex-hash.c
@@ -35,7 +35,7 @@ static unsigned int nfutexes = 1024;
 static bool fshared = false, done = false, silent = false;
 static int futex_flag = 0;
 
-struct timeval start, end, runtime;
+static struct timeval start, end, runtime;
 static pthread_mutex_t thread_lock;
 static unsigned int threads_starting;
 static struct stats throughput_stats;

--- a/tools/perf/builtin-trace.c
+++ b/tools/perf/builtin-trace.c
@@ -58,9 +58,9 @@
 #include <linux/stringify.h>
 #include <linux/time64.h>
 #include <fcntl.h>
-
+#include <sys/utsname.h>
 #include "sane_ctype.h"
-
+#define fldsz(name, field)  (sizeof(((struct name *)0)->field))
 #ifndef O_CLOEXEC
 # define O_CLOEXEC		02000000
 #endif
@@ -1775,7 +1775,8 @@ static int trace__fprintf_callchain(struct trace *trace, struct perf_sample *sam
 static const char *errno_to_name(struct perf_evsel *evsel, int err)
 {
 	struct perf_env *env = perf_evsel__env(evsel);
-	const char *arch_name = perf_env__arch(env);
+	char arch_name_buf[fldsz(utsname ,machine)];
+	const char *arch_name = perf_env__arch(env,arch_name_buf);
 
 	return arch_syscalls__strerrno(arch_name, err);
 }

--- a/tools/perf/tests/bp_account.c
+++ b/tools/perf/tests/bp_account.c
@@ -22,7 +22,7 @@
 #include "perf.h"
 #include "cloexec.h"
 
-volatile long the_var;
+static volatile long the_var;
 
 static noinline int test_function(void)
 {

--- a/tools/perf/tests/bp_signal.c
+++ b/tools/perf/tests/bp_signal.c
@@ -34,7 +34,7 @@ static int fd3;
 static int overflows;
 static int overflows_2;
 
-volatile long the_var;
+static volatile long the_var;
 
 
 /*

--- a/tools/perf/util/annotate.c
+++ b/tools/perf/util/annotate.c
@@ -29,7 +29,7 @@
 #include <pthread.h>
 #include <linux/bitops.h>
 #include <linux/kernel.h>
-
+#include <sys/utsname.h>
 /* FIXME: For the HE_COLORSET */
 #include "ui/browser.h"
 
@@ -43,7 +43,7 @@
 #define UARROW_CHAR	((unsigned char)'-')
 
 #include "sane_ctype.h"
-
+#define fldsz(name, field)  (sizeof(((struct name *)0)->field))
 struct annotation_options annotation__default_options = {
 	.use_offset     = true,
 	.jump_arrows    = true,
@@ -1866,7 +1866,8 @@ int symbol__annotate(struct symbol *sym, struct map *map,
 		.options	= options,
 	};
 	struct perf_env *env = perf_evsel__env(evsel);
-	const char *arch_name = perf_env__arch(env);
+	char arch_name_buf[fldsz(utsname ,machine)];
+	const char *arch_name = perf_env__arch(env, arch_name_buf);
 	struct arch *arch;
 	int err;
 

--- a/tools/perf/util/env.c
+++ b/tools/perf/util/env.c
@@ -139,8 +139,8 @@ static const char *normalize_arch(char *arch)
 {
 	if (!strcmp(arch, "x86_64"))
 		return "x86";
-	if (arch[0] == 'i' && arch[2] == '8' && arch[3] == '6')
-		return "x86";
+	if (!strncmp(arch, "i",1) && arch[1] && !strncmp(arch+2, "86", 2))
+	  return "x86";
 	if (!strcmp(arch, "sun4u") || !strncmp(arch, "sparc", 5))
 		return "sparc";
 	if (!strcmp(arch, "aarch64") || !strcmp(arch, "arm64"))
@@ -161,15 +161,16 @@ static const char *normalize_arch(char *arch)
 	return arch;
 }
 
-const char *perf_env__arch(struct perf_env *env)
+const char *perf_env__arch(struct perf_env *env, char *buf)
 {
 	struct utsname uts;
-	char *arch_name;
-
+	char *arch_name = 0;
+  const size_t uts_machine_len = sizeof(uts.machine); 
 	if (!env || !env->arch) { /* Assume local operation */
 		if (uname(&uts) < 0)
 			return NULL;
-		arch_name = uts.machine;
+    strncpy(buf,uts.machine,uts_machine_len);
+		arch_name = buf;
 	} else
 		arch_name = env->arch;
 

--- a/tools/perf/util/env.h
+++ b/tools/perf/util/env.h
@@ -75,7 +75,7 @@ int perf_env__read_cpu_topology_map(struct perf_env *env);
 
 void cpu_cache_level__free(struct cpu_cache_level *cache);
 
-const char *perf_env__arch(struct perf_env *env);
+const char *perf_env__arch(struct perf_env *env, char *arch_name_buf);
 const char *perf_env__raw_arch(struct perf_env *env);
 int perf_env__nr_cpus_avail(struct perf_env *env);
 

--- a/tools/perf/util/parse-events.c
+++ b/tools/perf/util/parse-events.c
@@ -177,7 +177,7 @@ static int tp_event_has_id(const char *dir_path, struct dirent *evt_dir)
 		    (strcmp(evt_dirent->d_name, "..")) &&	\
 		    (!tp_event_has_id(dir_path, evt_dirent)))
 
-#define MAX_EVENT_LENGTH 512
+
 
 
 struct tracepoint_path *tracepoint_id_to_path(u64 config)
@@ -190,7 +190,7 @@ struct tracepoint_path *tracepoint_id_to_path(u64 config)
 	u64 id;
 	char evt_path[MAXPATHLEN];
 	char *dir_path;
-
+  const size_t MAX_EVENT_LENGTH = sizeof(sys_dirent->d_name);
 	sys_dir = tracing_events__opendir();
 	if (!sys_dir)
 		return NULL;
@@ -234,10 +234,10 @@ struct tracepoint_path *tracepoint_id_to_path(u64 config)
 					free(path);
 					return NULL;
 				}
-				strncpy(path->system, sys_dirent->d_name,
-					MAX_EVENT_LENGTH);
+				strncpy(path->system, sys_dirent->d_name, 
+          MAX_EVENT_LENGTH);
 				strncpy(path->name, evt_dirent->d_name,
-					MAX_EVENT_LENGTH);
+          MAX_EVENT_LENGTH);
 				return path;
 			}
 		}

--- a/tools/perf/util/unwind-libunwind.c
+++ b/tools/perf/util/unwind-libunwind.c
@@ -4,7 +4,8 @@
 #include "session.h"
 #include "debug.h"
 #include "env.h"
-
+#include <sys/utsname.h>
+#define fldsz(name, field)  (sizeof(((struct name *)0)->field))
 struct unwind_libunwind_ops __weak *local_unwind_libunwind_ops;
 struct unwind_libunwind_ops __weak *x86_32_unwind_libunwind_ops;
 struct unwind_libunwind_ops __weak *arm64_unwind_libunwind_ops;
@@ -22,6 +23,7 @@ int unwind__prepare_access(struct thread *thread, struct map *map,
 	enum dso_type dso_type;
 	struct unwind_libunwind_ops *ops = local_unwind_libunwind_ops;
 	int err;
+	char arch_name_buf[fldsz(utsname ,machine)];
 
 	if (thread->addr_space) {
 		pr_debug("unwind: thread map already set, dso=%s\n",
@@ -39,7 +41,7 @@ int unwind__prepare_access(struct thread *thread, struct map *map,
 	if (dso_type == DSO__TYPE_UNKNOWN)
 		return 0;
 
-	arch = perf_env__arch(thread->mg->machine->env);
+	arch = perf_env__arch(thread->mg->machine->env, arch_name_buf);
 
 	if (!strcmp(arch, "x86")) {
 		if (dso_type != DSO__TYPE_64BIT)


### PR DESCRIPTION
fix tools/perf 3 bugs:
1 perf_env__arch return dangling pointer
2 normalize_arch function read out of bound when the arch is "i*86".
3 global variable like "the_var" defined in muliple files without "static" key word qualified, lead to linkage error.
