### PR TITLE
Add missing command to WSL2 build instructions

### DIFF
--- a/README-Microsoft.WSL2
+++ b/README-Microsoft.WSL2
@@ -1,5 +1,5 @@
 Build instructions:
 
 1. Install a recent Ubuntu distribution
-2. sudo install build-essential flex bison libssl-dev libelf-dev
+2. sudo apt install build-essential flex bison libssl-dev libelf-dev
 3. make KCONFIG_CONFIG=Microsoft/config-wsl


### PR DESCRIPTION
Missing 'apt' in the build instructions