### PR TITLE
PCI: hv: Reserve hv_pci swiotlb from buddy and publish via sysfs

### DIFF
--- a/drivers/pci/controller/pci-hyperv.c
+++ b/drivers/pci/controller/pci-hyperv.c
@@ -53,7 +53,6 @@
 #include <linux/sizes.h>
 #include <linux/of_irq.h>
 #include <linux/swiotlb.h>
-#include <linux/memblock.h>
 #include <asm/mshyperv.h>
 
 /*
@@ -472,17 +471,37 @@ static int pci_ring_size = VMBUS_RING_SIZE(SZ_16K);
 
 static phys_addr_t hv_pci_swiotlb_base;
 static size_t hv_pci_swiotlb_size;
+static bool hv_pci_swiotlb_published;
 
+#ifndef MODULE
+/*
+ * Parse hv_pci_swiotlb=<size>; the base is picked when the driver
+ * initializes.  early_param is only available in built-in builds, so the
+ * dedicated pool feature is effectively built-in only; module builds fall
+ * back to the default swiotlb pool.
+ */
 static int __init early_hv_pci_swiotlb(char *p)
 {
-    hv_pci_swiotlb_base = memparse(p, &p);
-    if (*p == ',')
-        hv_pci_swiotlb_size = memparse(p + 1, NULL);
-    if (hv_pci_swiotlb_base && hv_pci_swiotlb_size)
-        memblock_reserve(hv_pci_swiotlb_base, hv_pci_swiotlb_size);
-    return 0;
+	char *end;
+
+	if (!*p)
+		return 0;
+
+	hv_pci_swiotlb_size = memparse(p, &end);
+	if (*end != '\0') {
+		pr_warn("hv_pci: ignoring hv_pci_swiotlb=%s; expected hv_pci_swiotlb=<size>\n",
+			p);
+		hv_pci_swiotlb_size = 0;
+		return 0;
+	}
+
+	if (hv_pci_swiotlb_size)
+		hv_pci_swiotlb_size = ALIGN(hv_pci_swiotlb_size, SZ_2M);
+
+	return 0;
 }
 early_param("hv_pci_swiotlb", early_hv_pci_swiotlb);
+#endif /* !MODULE */
 
 static struct io_tlb_mem *hv_pci_swiotlb_pool;
 
@@ -4241,9 +4260,51 @@ static struct hv_driver hv_pci_drv = {
 	.resume		= hv_pci_resume,
 };
 
+/* Publish swiotlb_{base,size} so userspace can forward the GPA to the host. */
+static ssize_t swiotlb_base_show(struct device_driver *drv, char *buf)
+{
+	return sysfs_emit(buf, "0x%llx\n",
+			  (unsigned long long)hv_pci_swiotlb_base);
+}
+static DRIVER_ATTR_RO(swiotlb_base);
+
+static ssize_t swiotlb_size_show(struct device_driver *drv, char *buf)
+{
+	return sysfs_emit(buf, "%zu\n", hv_pci_swiotlb_size);
+}
+static DRIVER_ATTR_RO(swiotlb_size);
+
+static void hv_pci_swiotlb_unpublish(void)
+{
+	if (!hv_pci_swiotlb_published)
+		return;
+	driver_remove_file(&hv_pci_drv.driver, &driver_attr_swiotlb_size);
+	driver_remove_file(&hv_pci_drv.driver, &driver_attr_swiotlb_base);
+	hv_pci_swiotlb_published = false;
+}
+
+static void hv_pci_swiotlb_publish(void)
+{
+	if (driver_create_file(&hv_pci_drv.driver, &driver_attr_swiotlb_base))
+		goto warn;
+	if (driver_create_file(&hv_pci_drv.driver, &driver_attr_swiotlb_size)) {
+		driver_remove_file(&hv_pci_drv.driver, &driver_attr_swiotlb_base);
+		goto warn;
+	}
+	hv_pci_swiotlb_published = true;
+	return;
+
+warn:
+	pr_warn("hv_pci: failed to publish swiotlb range to sysfs\n");
+}
+
 static void __exit exit_hv_pci_drv(void)
 {
+	hv_pci_swiotlb_unpublish();
+
 	vmbus_driver_unregister(&hv_pci_drv);
+
+	/* No swiotlb_destroy_pool() exists, so the backing pages are leaked. */
 
 	hvpci_block_ops.read_block = NULL;
 	hvpci_block_ops.write_block = NULL;
@@ -4260,17 +4321,6 @@ static int __init init_hv_pci_drv(void)
 	if (hv_root_partition() && !hv_nested)
 		return -ENODEV;
 
-	if (hv_pci_swiotlb_base && hv_pci_swiotlb_size) {
-		hv_pci_swiotlb_pool = swiotlb_create_pool(hv_pci_swiotlb_base,
-							   hv_pci_swiotlb_size,
-							   "hv-pci-swiotlb");
-		if (IS_ERR(hv_pci_swiotlb_pool)) {
-			pr_err("hv_pci: failed to create swiotlb pool: %ld\n",
-			       PTR_ERR(hv_pci_swiotlb_pool));
-			hv_pci_swiotlb_pool = NULL;
-		}
-	}
-
 	ret = hv_pci_irqchip_init();
 	if (ret)
 		return ret;
@@ -4283,8 +4333,83 @@ static int __init init_hv_pci_drv(void)
 	hvpci_block_ops.write_block = hv_write_config_block;
 	hvpci_block_ops.reg_blk_invalidate = hv_register_block_invalidate;
 
-	return vmbus_driver_register(&hv_pci_drv);
+	ret = vmbus_driver_register(&hv_pci_drv);
+	if (ret)
+		return ret;
+
+	if (hv_pci_swiotlb_pool)
+		hv_pci_swiotlb_publish();
+
+	return 0;
 }
+
+#ifndef MODULE
+/*
+ * The dedicated swiotlb pool feature is built-in only: the cmdline parser
+ * uses early_param (unavailable in modules) and the allocation runs as a
+ * core_initcall so the buddy allocator hands us a 64 MiB DMA32 contiguous
+ * range with minimal fragmentation risk.  In module builds
+ * hv_pci_swiotlb_size stays 0 and the rest of the file's pool plumbing
+ * (probe, publish, exit) is naturally inert.
+ */
+#ifdef CONFIG_CONTIG_ALLOC
+/*
+ * Reserve the hv_pci swiotlb pool from the buddy allocator.  __GFP_DMA32
+ * keeps the range below 4 GiB; kernel ownership keeps Hyper-V page
+ * reporting from yanking the backing.  Gated on CONFIG_CONTIG_ALLOC.
+ */
+static int __init hv_pci_swiotlb_alloc_pool(void)
+{
+	phys_addr_t end;
+	unsigned long nr_pages;
+	struct page *pages;
+
+	if (!hv_pci_swiotlb_size)
+		return 0;
+
+	nr_pages = hv_pci_swiotlb_size >> PAGE_SHIFT;
+
+	/* UMA on WSL; first_online_node biases nothing in practice. */
+	pages = alloc_contig_pages(nr_pages,
+				   GFP_KERNEL | __GFP_DMA32 | __GFP_ZERO,
+				   first_online_node, &node_online_map);
+	if (!pages) {
+		pr_warn("hv_pci: failed to allocate %zu-byte swiotlb pool below 4G; feature disabled\n",
+			hv_pci_swiotlb_size);
+		hv_pci_swiotlb_size = 0;
+		return 0;
+	}
+
+	hv_pci_swiotlb_base = page_to_phys(pages);
+	end = hv_pci_swiotlb_base + hv_pci_swiotlb_size;
+
+	pr_info("hv_pci: reserved swiotlb pool [%pa..%pa)\n",
+		&hv_pci_swiotlb_base, &end);
+
+	hv_pci_swiotlb_pool = swiotlb_create_pool(hv_pci_swiotlb_base,
+						  hv_pci_swiotlb_size,
+						  "hv-pci-swiotlb");
+	if (IS_ERR(hv_pci_swiotlb_pool)) {
+		pr_err("hv_pci: failed to create swiotlb pool: %ld\n",
+		       PTR_ERR(hv_pci_swiotlb_pool));
+		hv_pci_swiotlb_pool = NULL;
+		free_contig_range(page_to_pfn(pages), nr_pages);
+		hv_pci_swiotlb_base = 0;
+		hv_pci_swiotlb_size = 0;
+	}
+
+	return 0;
+}
+#else
+static int __init hv_pci_swiotlb_alloc_pool(void)
+{
+	if (hv_pci_swiotlb_size)
+		pr_warn("hv_pci: CONFIG_CONTIG_ALLOC disabled; hv_pci_swiotlb= ignored\n");
+	return 0;
+}
+#endif
+core_initcall(hv_pci_swiotlb_alloc_pool);
+#endif /* !MODULE */
 
 module_init(init_hv_pci_drv);
 module_exit(exit_hv_pci_drv);

--- a/drivers/pci/controller/pci-hyperv.c
+++ b/drivers/pci/controller/pci-hyperv.c
@@ -4304,7 +4304,22 @@ static void __exit exit_hv_pci_drv(void)
 
 	vmbus_driver_unregister(&hv_pci_drv);
 
-	/* No swiotlb_destroy_pool() exists, so the backing pages are leaked. */
+	/*
+	 * vmbus_driver_unregister() above synchronously tears down every
+	 * hv_pci instance and its child PCI devices, so nothing still
+	 * references the dedicated swiotlb pool by the time we get here.
+	 */
+	if (hv_pci_swiotlb_pool) {
+		if (swiotlb_destroy_pool(hv_pci_swiotlb_pool))
+			pr_err("hv_pci: leaking %zu-byte swiotlb pool at %pa\n",
+			       hv_pci_swiotlb_size, &hv_pci_swiotlb_base);
+		else
+			free_contig_range(hv_pci_swiotlb_base >> PAGE_SHIFT,
+					  hv_pci_swiotlb_size >> PAGE_SHIFT);
+		hv_pci_swiotlb_pool = NULL;
+		hv_pci_swiotlb_base = 0;
+		hv_pci_swiotlb_size = 0;
+	}
 
 	hvpci_block_ops.read_block = NULL;
 	hvpci_block_ops.write_block = NULL;

--- a/drivers/pci/controller/pci-hyperv.c
+++ b/drivers/pci/controller/pci-hyperv.c
@@ -4347,16 +4347,16 @@ static int __init init_hv_pci_drv(void)
 /*
  * The dedicated swiotlb pool feature is built-in only: the cmdline parser
  * uses early_param (unavailable in modules) and the allocation runs as a
- * core_initcall so the buddy allocator hands us a 64 MiB DMA32 contiguous
- * range with minimal fragmentation risk.  In module builds
- * hv_pci_swiotlb_size stays 0 and the rest of the file's pool plumbing
- * (probe, publish, exit) is naturally inert.
+ * core_initcall so the buddy allocator hands us a large contiguous range
+ * with minimal fragmentation risk.  In module builds hv_pci_swiotlb_size
+ * stays 0 and the rest of the file's pool plumbing (probe, publish, exit)
+ * is naturally inert.
  */
 #ifdef CONFIG_CONTIG_ALLOC
 /*
- * Reserve the hv_pci swiotlb pool from the buddy allocator.  __GFP_DMA32
- * keeps the range below 4 GiB; kernel ownership keeps Hyper-V page
- * reporting from yanking the backing.  Gated on CONFIG_CONTIG_ALLOC.
+ * Reserve the hv_pci swiotlb pool from the buddy allocator.  Kernel
+ * ownership keeps Hyper-V page reporting from yanking the backing.  Gated
+ * on CONFIG_CONTIG_ALLOC.
  */
 static int __init hv_pci_swiotlb_alloc_pool(void)
 {
@@ -4371,10 +4371,10 @@ static int __init hv_pci_swiotlb_alloc_pool(void)
 
 	/* UMA on WSL; first_online_node biases nothing in practice. */
 	pages = alloc_contig_pages(nr_pages,
-				   GFP_KERNEL | __GFP_DMA32 | __GFP_ZERO,
+				   GFP_KERNEL | __GFP_ZERO,
 				   first_online_node, &node_online_map);
 	if (!pages) {
-		pr_warn("hv_pci: failed to allocate %zu-byte swiotlb pool below 4G; feature disabled\n",
+		pr_warn("hv_pci: failed to allocate %zu-byte swiotlb pool; feature disabled\n",
 			hv_pci_swiotlb_size);
 		hv_pci_swiotlb_size = 0;
 		return 0;

--- a/include/linux/swiotlb.h
+++ b/include/linux/swiotlb.h
@@ -187,6 +187,7 @@ phys_addr_t default_swiotlb_base(void);
 phys_addr_t default_swiotlb_limit(void);
 struct io_tlb_mem *swiotlb_create_pool(phys_addr_t base, size_t size,
 				       const char *name);
+int swiotlb_destroy_pool(struct io_tlb_mem *mem);
 #else
 static inline void swiotlb_init(bool addressing_limited, unsigned int flags)
 {

--- a/kernel/dma/swiotlb.c
+++ b/kernel/dma/swiotlb.c
@@ -1962,3 +1962,48 @@ struct io_tlb_mem *swiotlb_create_pool(phys_addr_t base, size_t size,
 	return mem;
 }
 EXPORT_SYMBOL_GPL(swiotlb_create_pool);
+
+/**
+ * swiotlb_destroy_pool() - tear down a pool created by swiotlb_create_pool()
+ * @mem:	The io_tlb_mem returned by swiotlb_create_pool().
+ *
+ * Re-encrypts the backing physical memory and frees the per-pool management
+ * structures (debugfs entries, slot/area arrays, @mem itself).  The backing
+ * physical memory is owned by the caller and is not freed by this function;
+ * the caller may safely free it (e.g. via free_contig_range()) iff this
+ * function returns 0.
+ *
+ * The caller must ensure that no device still references @mem via
+ * dev->dma_io_tlb_mem and that no in-flight DMA targets the pool's region
+ * before calling.
+ *
+ * Return:
+ * * %0 on success.
+ * * negative errno if re-encrypting the backing memory failed; in that case
+ *   no state is changed (caller may retry, or treat @mem and the backing
+ *   memory as permanently leaked).
+ */
+int swiotlb_destroy_pool(struct io_tlb_mem *mem)
+{
+	struct io_tlb_pool *pool = &mem->defpool;
+	size_t size = pool->end - pool->start;
+	int ret;
+
+	/*
+	 * Re-encrypt first.  If this fails (e.g. -EBUSY from the encryption
+	 * trylock), leave everything in place so the caller can either retry
+	 * or intentionally leak the whole pool rather than return shared
+	 * pages to the allocator on a confidential guest.
+	 */
+	ret = set_memory_encrypted((unsigned long)pool->vaddr,
+				   size >> PAGE_SHIFT);
+	if (ret)
+		return ret;
+
+	debugfs_remove_recursive(mem->debugfs);
+	kfree(pool->areas);
+	kfree(pool->slots);
+	kfree(mem);
+	return 0;
+}
+EXPORT_SYMBOL_GPL(swiotlb_destroy_pool);


### PR DESCRIPTION
## Summary

Reserve the dedicated hv_pci swiotlb pool from the buddy allocator at `core_initcall` time and publish the resulting `(base, size)` under `/sys/bus/vmbus/drivers/hv_pci/swiotlb_{base,size}` so userspace can forward the real GPA to the host-side device backend.  This replaces the old "host dictates a GPA" flow.

## Why

WSL container test runs intermittently saw the guest die with `WorkerExitType=StoppedOnReset WorkerExitDetail=TripleFault WorkerExitInitiator=GuestOS` between `io scheduler mq-deadline registered` and the next initcall.  Root cause: `memblock_reserve()` accepts ranges that are not actually backed by EPT, and `swiotlb_create_pool()` -> `swiotlb_init_io_tlb_pool()` then `memset`s 64 MiB of unbacked pages.

## What changed

* `hv_pci_swiotlb=<size>` is now the only accepted form. `early_hv_pci_swiotlb()` parses with `memparse(p, &end)` and rejects any unconsumed trailing characters with `pr_warn`, so the legacy `<base>,<size>` form (which `memparse(p, NULL)` would otherwise silently treat as just the leading hex base) is no longer accepted.
* `core_initcall(hv_pci_swiotlb_alloc_pool)` asks the buddy allocator for a contiguous DMA32 range via `alloc_contig_pages(__GFP_DMA32 | __GFP_ZERO, first_online_node, &node_online_map)`.  `__GFP_ZERO` faults every page in via the page allocator, so by the time `swiotlb_create_pool()` runs the memory is known-good.  Kernel ownership keeps Hyper-V page reporting from yanking the backing.  Running at `core_initcall` (initcall level 1) gives us the earliest possible shot at a fresh, mostly-empty DMA32 zone.
* Allocator path gated on `CONFIG_CONTIG_ALLOC` with a no-op stub fallback.
* The `hv_pci_swiotlb=` early_param and the alloc `core_initcall` are wrapped in `#ifndef MODULE`, because both `early_param` and `core_initcall` are unavailable from modules (otherwise `core_initcall` redefines `module_init`'s `init_module`).  Module builds compile cleanly and fall back to the default swiotlb pool.  The WSL config uses `CONFIG_PCI_HYPERV=y`, so the feature is active there.
* `(base, size)` published via `DRIVER_ATTR_RO` once `vmbus_driver_register()` succeeds. An `hv_pci_swiotlb_published` flag makes `publish()`/`unpublish()` symmetric and idempotent, so a partial sysfs-create failure cleans up only what it created and module exit can't double-unpublish.

## Validation

* `scripts/checkpatch.pl --strict -g HEAD` -> 0 errors, 0 warnings, 0 checks, 203 lines checked.
* `make W=1 drivers/pci/controller/pci-hyperv.o` is clean with both `CONFIG_PCI_HYPERV=y` and `CONFIG_PCI_HYPERV=m` (arm64 cross-build).
* Boot-tested under WSL2 with `swiotlb=force hv_pci_swiotlb=64M`:
  * `dmesg`: `hv_pci: reserved swiotlb pool [0x0000000008000000..0x000000000c000000)`
  * `/sys/bus/vmbus/drivers/hv_pci/swiotlb_base` -> `0x8000000`
  * `/sys/bus/vmbus/drivers/hv_pci/swiotlb_size` -> `67108864`

## Notes

`swiotlb` has no `destroy_pool()` counterpart to `swiotlb_create_pool()`, so the backing pages are deliberately leaked on driver unload.  hv_pci is rarely hot-replaced and the pool is bounded (default 64 MiB).
